### PR TITLE
fix: camelCase request port options

### DIFF
--- a/example/helper.ts
+++ b/example/helper.ts
@@ -34,7 +34,7 @@ const disconnectEventListener = async () => await disconnectEscan();
 export const connect250 = async () => {
   try {
     port250 = await navigator.serial.requestPort({
-       /* filters: [
+      /* filters: [
           {
             usbVendorId: 0x0403, // FTDI
             usbProductId: 0x6001,

--- a/example/helper.ts
+++ b/example/helper.ts
@@ -34,12 +34,12 @@ const disconnectEventListener = async () => await disconnectEscan();
 export const connect250 = async () => {
   try {
     port250 = await navigator.serial.requestPort({
-      /* filters: [
+       filters: [
           {
-            vendorId: 0x0403, // FTDI
-            productId: 0x6001,
+            usbVendorId: 0x0403, // FTDI
+            usbProductId: 0x6001,
           },
-        ],*/
+        ],
     });
 
     console.log("250 port acquired", port250);

--- a/example/helper.ts
+++ b/example/helper.ts
@@ -34,12 +34,12 @@ const disconnectEventListener = async () => await disconnectEscan();
 export const connect250 = async () => {
   try {
     port250 = await navigator.serial.requestPort({
-       filters: [
+       /* filters: [
           {
             usbVendorId: 0x0403, // FTDI
             usbProductId: 0x6001,
           },
-        ],
+        ],*/
     });
 
     console.log("250 port acquired", port250);

--- a/example/serial-types.ts
+++ b/example/serial-types.ts
@@ -69,7 +69,7 @@ declare global {
     serial: {
       onconnect: EventHandlerNonNull;
       ondisconnect: EventHandlerNonNull;
-      requestPort(options: SerialPortRequestOptions): Promise<SerialPort>;
+      requestPort(options: SerialOptions): Promise<SerialPort>;
       getPorts(): Promise<Iterable<SerialPort>>;
     };
   }

--- a/example/serial-types.ts
+++ b/example/serial-types.ts
@@ -27,6 +27,15 @@ export interface SerialOptions {
   xany?: boolean;
 }
 
+interface SerialPortRequestOptions {
+  filters: SerialPortFilter[];
+}
+
+interface SerialPortFilter {
+  usbVendorId: number;
+  usbProductId?: number | undefined;
+}
+
 interface SerialPortInfo {
   readonly serialNumber: string;
   readonly manufacturer: string;
@@ -69,7 +78,7 @@ declare global {
     serial: {
       onconnect: EventHandlerNonNull;
       ondisconnect: EventHandlerNonNull;
-      requestPort(options: SerialOptions): Promise<SerialPort>;
+      requestPort(options: SerialPortRequestOptions): Promise<SerialPort>;
       getPorts(): Promise<Iterable<SerialPort>>;
     };
   }

--- a/example/serial-types.ts
+++ b/example/serial-types.ts
@@ -1,5 +1,5 @@
 export interface SerialOptions {
-  baudrate?:
+  baudRate:
     | 115200
     | 57600
     | 38400
@@ -17,23 +17,14 @@ export interface SerialOptions {
     | 110
     | 75
     | 50;
-  stopbits?: 1 | 2;
-  databits?: 8 | 7 | 6 | 5;
+  stopBits?: 1 | 2;
+  dataBits?: 8 | 7 | 6 | 5;
   parity?: (typeof ParityType)[keyof typeof ParityType];
-  buffersize?: number;
+  bufferSize?: number;
   rtscts?: boolean;
   xon?: boolean;
   xoff?: boolean;
   xany?: boolean;
-}
-
-interface SerialPortRequestOptions {
-  filters: SerialPortFilter[];
-}
-
-interface SerialPortFilter {
-  usbVendorId: number;
-  usbProductId?: number | undefined;
 }
 
 interface SerialPortInfo {

--- a/src/transform-stream-250.ts
+++ b/src/transform-stream-250.ts
@@ -22,7 +22,7 @@ export type Ecard250 = {
 };
 
 export const serialOptions250 = {
-  baudrate: 9600,
+  baudRate: 9600,
   stopbits: 2,
   parity: "none",
   databits: 8,

--- a/src/transform-stream-250.ts
+++ b/src/transform-stream-250.ts
@@ -23,9 +23,9 @@ export type Ecard250 = {
 
 export const serialOptions250 = {
   baudRate: 9600,
-  stopbits: 2,
+  stopBits: 2,
   parity: "none",
-  databits: 8,
+  dataBits: 8,
 };
 
 const ecardLength = 217;

--- a/src/transform-stream-mtr4.ts
+++ b/src/transform-stream-mtr4.ts
@@ -11,10 +11,10 @@ import {
 } from "./transform-stream-utils";
 
 export const serialOptionsMtr4 = {
-  baudrate: 9600,
-  stopbits: 1,
+  baudRate: 9600,
+  stopBits: 1,
   parity: "none",
-  databits: 8,
+  dataBits: 8,
 };
 
 export type EcardMtr = {


### PR DESCRIPTION
Getting an exception without this change on Mac/Chrome/250 reader. Didn't inspect it more, but my guess is some chrome API is now more picky than it used to be. Don't yet have any eCards at my hand, but at least now the connection opens properly.