### PR TITLE
fix: gate eScan debug logging behind NODE_ENV=development

### DIFF
--- a/src/transform-stream-escan.ts
+++ b/src/transform-stream-escan.ts
@@ -7,6 +7,11 @@ import {
   USB_STOP_READ_BYTE,
 } from "./transform-stream-utils";
 
+// Only log in development (NODE_ENV=development in Node.js; bundlers substitute this in browser)
+const isDev =
+  (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env
+    ?.NODE_ENV === "development";
+
 export type UsbFrame = {
   productName: "eScan" | "ECU";
   hardwareVersion: string;
@@ -161,16 +166,18 @@ export class EmitEscanUnpacker {
       frame = this.parseDumpTag(range);
     } else if (this.data[this.readPosition] === iByte) {
       frame = this.parseFrame(range);
-    } else {
+    } else if (isDev) {
       console.error("Unknown starting byte", this.data[this.readPosition]);
     }
-    console.log(
-      `Frame: ${frameSize}, datalength: ${this.data.byteLength}, readPos: ${this.readPosition}, finPos: ${completeReadingPosition}`,
-      frame,
-      new TextDecoder("utf-8").decode(
-        getRangeFromRingBuffer(this.data, this.readPosition, frameSize),
-      ),
-    );
+    if (isDev) {
+      console.log(
+        `Frame: ${frameSize}, datalength: ${this.data.byteLength}, readPos: ${this.readPosition}, finPos: ${completeReadingPosition}`,
+        frame,
+        new TextDecoder("utf-8").decode(
+          getRangeFromRingBuffer(this.data, this.readPosition, frameSize),
+        ),
+      );
+    }
     this.onChunk && this.onChunk(frame);
   }
 }


### PR DESCRIPTION
## Summary

- Removes unconditional `console.log` / `console.error` calls from `EmitEscanUnpacker.checkForChunks()` that printed raw byte data on every frame in production
- Logging is now opt-in: a module-level `isDev` flag reads `process?.env?.NODE_ENV` via `globalThis`, which is `"development"` only when running in a Node.js dev environment or when a bundler (Vite, webpack, etc.) substitutes the value at build time

## Test plan

- [ ] `npm run build` passes (no new TypeScript errors)
- [ ] In production (default): no console output when processing eScan frames
- [ ] With `NODE_ENV=development` set: `console.log` frame diagnostics and `console.error` for unknown start bytes appear as before

Closes part of #418
🤖 Generated with [Claude Code](https://claude.com/claude-code)