### PR TITLE
docs: correct package name in README install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ does also work on Chrome for Android.
 This library is published to NPM as ES modules (no CommonJS/IIFE):
 
 ```shell
-npm install @mikaello/emit-punch-card-communication
+npm install @mikaello/emit-punch-cards-communication
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Fixes the npm install command in README which showed `@mikaello/emit-punch-card-communication` (missing the `s` in `cards`)
- Correct name is `@mikaello/emit-punch-cards-communication`, matching the published package

## Test plan

- [ ] Copy-paste the install command from README and verify it resolves to the correct package

Closes part of #418
🤖 Generated with [Claude Code](https://claude.com/claude-code)