### PR TITLE
fix: surface MTR4 protocol mismatch errors via stream error path

### DIFF
--- a/src/transform-stream-mtr4.ts
+++ b/src/transform-stream-mtr4.ts
@@ -168,7 +168,7 @@ class Mtr4Unpacker {
     );
 
     if (packageType !== PackageType.EcardMtr) {
-      console.error("Wrong package type: " + packageType);
+      throw new Error(`MTR4 protocol mismatch: expected ecard type '${PackageType.EcardMtr}', got '${packageType}'`);
     }
 
     const batteryStatus =
@@ -236,7 +236,7 @@ class Mtr4Unpacker {
     );
 
     if (packageType !== PackageType.StatusMessage) {
-      console.error("Wrong package type: " + packageType);
+      throw new Error(`MTR4 protocol mismatch: expected status type '${PackageType.StatusMessage}', got '${packageType}'`);
     }
 
     const batteryStatus =

--- a/src/transform-stream-mtr4.ts
+++ b/src/transform-stream-mtr4.ts
@@ -168,7 +168,9 @@ class Mtr4Unpacker {
     );
 
     if (packageType !== PackageType.EcardMtr) {
-      throw new Error(`MTR4 protocol mismatch: expected ecard type '${PackageType.EcardMtr}', got '${packageType}'`);
+      throw new Error(
+        `MTR4 protocol mismatch: expected ecard type '${PackageType.EcardMtr}', got '${packageType}'`,
+      );
     }
 
     const batteryStatus =
@@ -236,7 +238,9 @@ class Mtr4Unpacker {
     );
 
     if (packageType !== PackageType.StatusMessage) {
-      throw new Error(`MTR4 protocol mismatch: expected status type '${PackageType.StatusMessage}', got '${packageType}'`);
+      throw new Error(
+        `MTR4 protocol mismatch: expected status type '${PackageType.StatusMessage}', got '${packageType}'`,
+      );
     }
 
     const batteryStatus =


### PR DESCRIPTION
## Summary

- Replaces `console.error("Wrong package type: ...")` in `Mtr4Unpacker.parseEcard` and `parseStatusMessage` with thrown `Error` instances
- The thrown error propagates through `checkForChunks` → `addBinaryData` → the `TransformStream`'s `transform` callback, causing the WebStreams runtime to error the readable side
- Consumers can now handle protocol mismatches via the stream's error event instead of silently receiving only console noise

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes (all 42 tests)
- [ ] A consumer piping `Mtr4TransformStream` can catch protocol mismatch failures via `.pipeTo(...).catch(...)` or a `WritableStream` error handler

Closes part of #418
🤖 Generated with [Claude Code](https://claude.com/claude-code)